### PR TITLE
ハズレの操作で操作する配列が間違っていたので修正

### DIFF
--- a/tools.js
+++ b/tools.js
@@ -71,7 +71,7 @@ function cast_lose_lots(array){
         if(local_array[i] == 0) {
             your_num = local_array[i];
             local_array.splice(i, 1);
-            var s_local_array = shuffle(lottery);
+            var s_local_array = shuffle(local_array);
             return [your_num, s_local_array];
         }
     }


### PR DESCRIPTION
ハズレくじを引いたあとのくじの確率については修正したつもりだったが、操作する配列が異なっていたため、再度修正。